### PR TITLE
fix: CI pnpmバージョン重複エラーを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 10.11.0
 
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
mainブランチでCI失敗している `ERR_PNPM_BAD_PM_VERSION` エラーを修正します。

## 問題
```
Error: Multiple versions of pnpm specified:
- version 10 in the GitHub Action config with the key "version"  
- version pnpm@10.11.0 in the package.json with the key "packageManager"
```

## 修正内容
- ✅ GitHub Actionsワークフローの`pnpm/action-setup@v4`から`version`指定を削除
- ✅ `package.json`の`packageManager: "pnpm@10.11.0"`から自動取得されるように変更
- ✅ `build.yml`と`deploy-docs.yml`両方で統一修正

## 影響範囲
- 🔧 `.github/workflows/build.yml`
- 🔧 `.github/workflows/deploy-docs.yml`

## 動作確認
このPRマージ後、mainブランチのCIが正常に動作することを確認できます。

## 関連
- 失敗したワークフロー: https://github.com/mzkmnk/quincy/actions/runs/16234538736

🤖 Generated with [Claude Code](https://claude.ai/code)