### PR TITLE
feat: WebSocket認証システムを削除してローカル開発を簡素化

### DIFF
--- a/apps/backend/src/routes/websocket.ts
+++ b/apps/backend/src/routes/websocket.ts
@@ -12,15 +12,23 @@ websocket.get('/status', (_req: Request, res: Response) => {
       connection: 'ws://localhost:3000/socket.io/',
       events: {
         client_to_server: [
-          'auth:request',
+          'q:command',
+          'q:abort',
+          'q:history',
+          'q:projects',
+          'q:resume',
           'message:send',
           'room:join',
           'room:leave',
           'ping'
         ],
         server_to_client: [
-          'auth:success',
-          'auth:failure',
+          'q:response',
+          'q:error',
+          'q:complete',
+          'q:history:data',
+          'q:history:list',
+          'session:created',
           'message:received',
           'message:broadcast',
           'room:joined',
@@ -47,7 +55,8 @@ websocket.get('/info', (_req: Request, res: Response) => {
       transports: ['websocket', 'polling']
     },
     features: [
-      'Authentication',
+      'Amazon Q CLI Integration',
+      'History Management',
       'Message Broadcasting',
       'Room Management',
       'Error Handling',

--- a/apps/backend/src/services/websocket.ts
+++ b/apps/backend/src/services/websocket.ts
@@ -64,7 +64,6 @@ export class WebSocketService {
         socket.data = {
           authenticated: false,
           rooms: [],
-          userId: undefined,
           sessionId: undefined
         };
         
@@ -86,7 +85,6 @@ export class WebSocketService {
       
       const connectionInfo: ConnectionInfo = {
         socketId: socket.id,
-        userId: process.env.LOCAL_USER_ID || 'local-user',
         sessionId: `session_${Date.now()}`,
         connectedAt: Date.now(),
         authenticated: isDevelopment
@@ -216,7 +214,6 @@ export class WebSocketService {
 
     const joinEvent: RoomJoinedEvent = {
       roomId,
-      userId: socket.data.userId || socket.id,
       timestamp: Date.now()
     };
 
@@ -226,13 +223,13 @@ export class WebSocketService {
     // Notify other users in the room
     socket.to(roomId).emit('message:broadcast', {
       id: this.generateMessageId(),
-      content: `${socket.data.userId || 'Anonymous'} joined the room`,
+      content: `User joined the room`,
       senderId: 'system',
       timestamp: Date.now(),
       type: 'system'
     });
 
-    console.log(`🏠 User ${socket.data.userId || socket.id} joined room: ${roomId}`);
+    console.log(`🏠 Socket ${socket.id} joined room: ${roomId}`);
   }
 
   private handleRoomLeave(socket: Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>, data: RoomData) {
@@ -251,7 +248,6 @@ export class WebSocketService {
 
     const leaveEvent: RoomLeftEvent = {
       roomId,
-      userId: socket.data.userId || socket.id,
       timestamp: Date.now()
     };
 
@@ -261,13 +257,13 @@ export class WebSocketService {
     // Notify other users in the room
     socket.to(roomId).emit('message:broadcast', {
       id: this.generateMessageId(),
-      content: `${socket.data.userId || 'Anonymous'} left the room`,
+      content: `User left the room`,
       senderId: 'system',
       timestamp: Date.now(),
       type: 'system'
     });
 
-    console.log(`🏠 User ${socket.data.userId || socket.id} left room: ${roomId}`);
+    console.log(`🏠 Socket ${socket.id} left room: ${roomId}`);
   }
 
   private handleDisconnection(socket: Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>) {
@@ -280,7 +276,7 @@ export class WebSocketService {
       userRooms.forEach(roomId => {
         socket.to(roomId).emit('message:broadcast', {
           id: this.generateMessageId(),
-          content: `${socket.data.userId || 'Anonymous'} disconnected`,
+          content: `User disconnected`,
           senderId: 'system',
           timestamp: Date.now(),
           type: 'system'
@@ -375,7 +371,7 @@ export class WebSocketService {
         projectId: socket.data.sessionId || 'unknown'
       });
 
-      console.log(`🤖 Amazon Q CLI session started: ${sessionId} for user ${socket.data.userId}`);
+      console.log(`🤖 Amazon Q CLI session started: ${sessionId} for socket ${socket.id}`);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.sendError(socket, 'Q_COMMAND_ERROR', `Failed to start Amazon Q CLI: ${errorMessage}`);
@@ -387,7 +383,7 @@ export class WebSocketService {
       const success = await this.qCliService.abortSession(data.sessionId, 'user_request');
       
       if (success) {
-        console.log(`🛑 Amazon Q CLI session aborted: ${data.sessionId} by user ${socket.data.userId}`);
+        console.log(`🛑 Amazon Q CLI session aborted: ${data.sessionId} by socket ${socket.id}`);
       } else {
         this.sendError(socket, 'Q_ABORT_ERROR', `Session ${data.sessionId} not found or already terminated`);
       }

--- a/apps/backend/src/tests/websocket.test.ts
+++ b/apps/backend/src/tests/websocket.test.ts
@@ -7,8 +7,6 @@ import { WebSocketService } from '../services/websocket.ts'
 import { createServer, Server } from 'http'
 import { io as Client, Socket as ClientSocket } from 'socket.io-client'
 import type { 
-  AuthenticationData, 
-  ConnectionInfo, 
   MessageSendEvent, 
   MessageData 
 } from '@quincy/shared'
@@ -50,88 +48,46 @@ describe('WebSocket Server', () => {
     done()
   })
 
-  it('should handle authentication requests', (done) => {
-    const authData: AuthenticationData = {
-      userId: 'test-user',
-      sessionId: 'test-session'
-    }
-
-    clientSocket.emit('auth:request', authData)
-    
-    clientSocket.on('auth:success', (data: ConnectionInfo) => {
-      expect(data.userId).toBe('test-user')
-      expect(data.sessionId).toBe('test-session')
-      expect(data.authenticated).toBe(true)
-      expect(data.socketId).toBeDefined()
-      done()
-    })
-  })
-
-  it('should reject invalid authentication', (done) => {
-    const invalidAuthData: AuthenticationData = {}
-
-    clientSocket.emit('auth:request', invalidAuthData)
-    
-    clientSocket.on('auth:failure', (error) => {
-      expect(error.code).toBe('INVALID_AUTH')
-      expect(error.message).toContain('sessionId or userId required')
-      done()
-    })
-  })
 
   it('should handle message broadcasting', (done) => {
-    // First authenticate
-    clientSocket.emit('auth:request', { userId: 'test-user' })
+    // Create second client to receive broadcast
+    const secondClient = Client(`http://localhost:${port}`)
     
-    clientSocket.on('auth:success', () => {
-      // Create second client to receive broadcast
-      const secondClient = Client(`http://localhost:${port}`)
-      
-      secondClient.on('connect', () => {
-        secondClient.emit('auth:request', { userId: 'test-user-2' })
+    secondClient.on('connect', () => {
+      // Listen for broadcast message
+      secondClient.on('message:broadcast', (data: MessageData) => {
+        expect(data.content).toBe('Hello, world!')
+        expect(data.senderId).toBe('test-user')
+        expect(data.type).toBe('text')
+        secondClient.close()
+        done()
       })
       
-      secondClient.on('auth:success', () => {
-        // Listen for broadcast message
-        secondClient.on('message:broadcast', (data: MessageData) => {
-          expect(data.content).toBe('Hello, world!')
-          expect(data.senderId).toBe('test-user')
-          expect(data.type).toBe('text')
-          secondClient.close()
-          done()
-        })
-        
-        // Send message from first client
-        const messageData: MessageSendEvent = {
-          content: 'Hello, world!',
-          senderId: 'test-user',
-          type: 'text'
-        }
-        clientSocket.emit('message:send', messageData)
-      })
+      // Send message from first client (no authentication needed in development)
+      const messageData: MessageSendEvent = {
+        content: 'Hello, world!',
+        senderId: 'test-user',
+        type: 'text'
+      }
+      clientSocket.emit('message:send', messageData)
     })
   })
 
   it('should handle room management', (done) => {
-    // Authenticate first
-    clientSocket.emit('auth:request', { userId: 'test-user' })
+    // Join a room (no authentication needed in development)
+    clientSocket.emit('room:join', { roomId: 'test-room' })
     
-    clientSocket.on('auth:success', () => {
-      // Join a room
-      clientSocket.emit('room:join', { roomId: 'test-room' })
+    clientSocket.on('room:joined', (data) => {
+      expect(data.roomId).toBe('test-room')
+      expect(data.timestamp).toBeDefined()
       
-      clientSocket.on('room:joined', (data) => {
+      // Leave the room
+      clientSocket.emit('room:leave', { roomId: 'test-room' })
+      
+      clientSocket.on('room:left', (data) => {
         expect(data.roomId).toBe('test-room')
-        expect(data.userId).toBe('test-user')
-        
-        // Leave the room
-        clientSocket.emit('room:leave', { roomId: 'test-room' })
-        
-        clientSocket.on('room:left', (data) => {
-          expect(data.roomId).toBe('test-room')
-          expect(data.userId).toBe('test-user')
-          done()
-        })
+        expect(data.timestamp).toBeDefined()
+        done()
       })
     })
   })

--- a/apps/frontend/src/app/features/projects/projects.component.ts
+++ b/apps/frontend/src/app/features/projects/projects.component.ts
@@ -102,15 +102,9 @@ export class ProjectsComponent implements OnInit {
   private setupWebSocketListeners(): void {
     this.webSocketService.connect();
     
-    // WebSocket接続完了後に認証
+    // WebSocket接続完了後に直接Amazon Q履歴を取得
     this.webSocketService.on('connect', () => {
-      console.log('WebSocket connected, authenticating...');
-      this.webSocketService.emit('auth:request', { userId: 'amazon-q-user' });
-    });
-    
-    // 認証成功後にAmazon Q履歴を取得
-    this.webSocketService.on('auth:success', () => {
-      console.log('Authentication successful, loading Amazon Q history...');
+      console.log('WebSocket connected, loading Amazon Q history...');
       this.webSocketService.getAllProjectsHistory();
     });
     

--- a/apps/frontend/src/app/shared/components/project-list/project-list.component.ts
+++ b/apps/frontend/src/app/shared/components/project-list/project-list.component.ts
@@ -90,15 +90,9 @@ export class ProjectListComponent implements OnInit {
   private setupWebSocketListeners(): void {
     this.webSocketService.connect();
 
-    // WebSocket接続完了後に認証
+    // WebSocket接続完了後に直接Amazon Q履歴を取得
     this.webSocketService.on('connect', () => {
-      console.log('WebSocket connected, authenticating...');
-      this.webSocketService.emit('auth:request', { userId: 'amazon-q-user' });
-    });
-
-    // 認証成功後にAmazon Q履歴を取得
-    this.webSocketService.on('auth:success', () => {
-      console.log('Authentication successful, loading Amazon Q history...');
+      console.log('WebSocket connected, loading Amazon Q history...');
       this.webSocketService.getAllProjectsHistory();
     });
 

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -14,7 +14,6 @@ export interface ClientToServerEvents {
   'shell:init': (data: ShellInitEvent) => void;
   'shell:input': (data: ShellInputEvent) => void;
   'shell:resize': (data: ShellResizeEvent) => void;
-  'auth:request': (data: AuthenticationData) => void;
   'message:send': (data: MessageSendEvent) => void;
   'room:join': (data: RoomData) => void;
   'room:leave': (data: RoomData) => void;
@@ -37,8 +36,6 @@ export interface ServerToClientEvents {
   'shell:output': (data: ShellOutputEvent) => void;
   'shell:exit': (data: ShellExitEvent) => void;
   'session:created': (data: SessionCreatedEvent) => void;
-  'auth:success': (data: ConnectionInfo) => void;
-  'auth:failure': (data: ErrorData) => void;
   'message:received': (data: MessageData) => void;
   'message:broadcast': (data: MessageData) => void;
   'room:joined': (data: RoomJoinedEvent) => void;
@@ -141,9 +138,7 @@ export interface SessionCreatedEvent {
 
 // 新しいWebSocket通信用の型定義
 export interface AuthenticationData {
-  token?: string;
   sessionId?: string;
-  userId?: string;
 }
 
 export interface MessageData {
@@ -169,13 +164,11 @@ export interface RoomData {
 
 export interface RoomJoinedEvent {
   roomId: string;
-  userId: string;
   timestamp: number;
 }
 
 export interface RoomLeftEvent {
   roomId: string;
-  userId: string;
   timestamp: number;
 }
 
@@ -187,7 +180,6 @@ export interface ErrorData {
 
 export interface ConnectionInfo {
   socketId: string;
-  userId?: string;
   sessionId?: string;
   connectedAt: number;
   authenticated: boolean;
@@ -195,7 +187,6 @@ export interface ConnectionInfo {
 
 // Socket.ioのSocket型用のデータ
 export interface SocketData {
-  userId?: string;
   sessionId?: string;
   authenticated: boolean;
   rooms: string[];


### PR DESCRIPTION
## Summary
- WebSocket認証システムを削除し、ローカル開発環境でのユーザーエクスペリエンスを大幅に向上
- ページリロード時の「Authentication timeout」エラーを完全解決
- シングルユーザー・ローカル環境に適した簡素な実装に変更

## 変更内容

### バックエンド (`apps/backend/src/services/websocket.ts`)
- 30秒の認証タイムアウト処理を削除
- 全イベントハンドラーから認証チェックを削除
- 接続時に自動認証する仕組みを実装
- `handleAuthentication`メソッドを削除

### フロントエンド (`apps/frontend/src/app/shared/components/project-list/project-list.component.ts`)
- `auth:request`/`auth:success`イベント処理を削除
- WebSocket接続後、直接Amazon Q履歴を取得するよう変更

## 解決される問題
- ブラウザリロード時の認証タイムアウトエラー
- 不要な認証プロセスによる複雑性
- ローカル開発での接続問題

## テスト結果
- ✅ バックエンドビルド成功
- ✅ フロントエンドビルド成功
- ✅ 認証関連エラーの解消確認

## 技術的背景
このアプリケーションは個人開発者がローカル環境でクローンして使用することを前提としており、マルチユーザー認証は不要です。Amazon Q CLIへの認証委譲により、WebSocketレベルでの認証は形式的なものに過ぎませんでした。

🤖 Generated with [Claude Code](https://claude.ai/code)